### PR TITLE
Suppress alert dialog on errors with datatable

### DIFF
--- a/private/hotspot-i18n.php
+++ b/private/hotspot-i18n.php
@@ -96,7 +96,7 @@ function i18n_init() {
   $languages = json_decode(file_get_contents($file));
 
   // only enable this, when we do new mass translating
-  if ($generate_json_i18n == true) {
+  if (isset($generate_json_i18n) && $generate_json_i18n == true) {
     i18n_update_json();
   }
 

--- a/private/site.php
+++ b/private/site.php
@@ -30,6 +30,9 @@ if (!defined('HOTSPOT')) { exit; }
   <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
+  <!--  suppress alert dialog on errors -->
+  <script type="text/javascript">$.fn.dataTable.ext.errMode = 'throw';</script>
+  
   <!--  jquery dataTables -->
   <link rel="stylesheet" href="https://cdn.datatables.net/1.10.15/css/dataTables.bootstrap.min.css"/>
   <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"></script>


### PR DESCRIPTION
With empty data returned, a dialog box comes up because it also throws a 404 error. This suppresses the error for the user and sends it to the JavaScript console. (https://datatables.net/manual/tech-notes/7)